### PR TITLE
[Fix] Missing dependencies

### DIFF
--- a/.changeset/funny-guests-walk.md
+++ b/.changeset/funny-guests-walk.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/react-native-quick-sqlite': patch
+---
+
+Fixed: Missing dependency for `uuid` and race condition where ommitting `await` on some lock/transaction operations could deadlock the application's main thread.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,17 +14,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Gradle Cache
-        uses: gradle/gradle-build-action@v2
+      # - name: Gradle Cache
+      #   uses: gradle/gradle-build-action@v2
 
-      - name: AVD Cache
-        uses: actions/cache@v3
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-29
+      # - name: AVD Cache
+      #   uses: actions/cache@v3
+      #   id: avd-cache
+      #   with:
+      #     path: |
+      #       ~/.android/avd/*
+      #       ~/.android/adb*
+      #     key: avd-29
 
       - name: Setup NodeJS
         uses: actions/setup-node@v2
@@ -52,18 +52,18 @@ jobs:
           cd tests
           yarn install --frozen-lockfile
 
-      - name: create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 29
-          force-avd-creation: false
-          target: google_apis
-          arch: x86_64
-          disable-animations: false
-          avd-name: $AVD_NAME
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          script: echo "Generated AVD snapshot for caching."
+      # - name: create AVD and generate snapshot for caching
+      #   if: steps.avd-cache.outputs.cache-hit != 'true'
+      #   uses: reactivecircus/android-emulator-runner@v2
+      #   with:
+      #     api-level: 29
+      #     force-avd-creation: false
+      #     target: google_apis
+      #     arch: x86_64
+      #     disable-animations: false
+      #     avd-name: $AVD_NAME
+      #     emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+      #     script: echo "Generated AVD snapshot for caching."
 
       - name: Run connected tests
         uses: ReactiveCircus/android-emulator-runner@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,17 +14,17 @@ jobs:
         with:
           persist-credentials: false
 
-      # - name: Gradle Cache
-      #   uses: gradle/gradle-build-action@v2
+      - name: Gradle Cache
+        uses: gradle/gradle-build-action@v2
 
-      # - name: AVD Cache
-      #   uses: actions/cache@v3
-      #   id: avd-cache
-      #   with:
-      #     path: |
-      #       ~/.android/avd/*
-      #       ~/.android/adb*
-      #     key: avd-29
+      - name: AVD Cache
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-29
 
       - name: Setup NodeJS
         uses: actions/setup-node@v2
@@ -52,18 +52,18 @@ jobs:
           cd tests
           yarn install --frozen-lockfile
 
-      # - name: create AVD and generate snapshot for caching
-      #   if: steps.avd-cache.outputs.cache-hit != 'true'
-      #   uses: reactivecircus/android-emulator-runner@v2
-      #   with:
-      #     api-level: 29
-      #     force-avd-creation: false
-      #     target: google_apis
-      #     arch: x86_64
-      #     disable-animations: false
-      #     avd-name: $AVD_NAME
-      #     emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-      #     script: echo "Generated AVD snapshot for caching."
+      - name: create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 29
+          force-avd-creation: false
+          target: google_apis
+          arch: x86_64
+          disable-animations: false
+          avd-name: $AVD_NAME
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          script: echo "Generated AVD snapshot for caching."
 
       - name: Run connected tests
         uses: ReactiveCircus/android-emulator-runner@v2

--- a/cpp/ConnectionState.cpp
+++ b/cpp/ConnectionState.cpp
@@ -92,8 +92,10 @@ void ConnectionState::doWork() {
     ++threadBusy;
     task(connection);
     --threadBusy;
+    // Need to notify in order for waitFinished to be updated when
+    // the queue is empty and not busy
+    workQueueConditionVariable.notify_all();
   }
-  workQueueConditionVariable.notify_all();
 }
 
 void ConnectionState::waitFinished() {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     ]
   },
   "dependencies": {
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "uuid": "3.4.0"
   }
 }

--- a/tests/App.tsx
+++ b/tests/App.tsx
@@ -15,15 +15,14 @@ export default function App() {
 
     try {
       const results = await runTests(registerBaseTests);
-
+      console.log(JSON.stringify(results, null, '\t'));
+      setResults(results);
       // Send results to host server
       await fetch(TEST_SERVER_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(results)
       });
-      console.log(JSON.stringify(results, null, '\t'));
-      setResults(results);
     } catch (ex) {
       console.error(ex);
       // Send results to host server

--- a/tests/tests/mocha/MochaRNAdapter.ts
+++ b/tests/tests/mocha/MochaRNAdapter.ts
@@ -5,6 +5,7 @@ export const rootSuite = new Mocha.Suite('') as MochaTypes.Suite;
 rootSuite.timeout(10 * 1000);
 
 let mochaContext = rootSuite;
+
 let only = false;
 
 export const clearTests = () => {
@@ -14,20 +15,18 @@ export const clearTests = () => {
   only = false;
 };
 
-export const it = (
-  name: string,
-  f: MochaTypes.Func | MochaTypes.AsyncFunc,
-): void => {
+export const it = (name: string, f: MochaTypes.Func | MochaTypes.AsyncFunc): void => {
   if (!only) {
-    const test = new Mocha.Test(name, f);
+    const test = new Mocha.Test(name, async () => {
+      console.log(`Running ${name}`);
+      // @ts-ignore
+      return f();
+    });
     mochaContext.addTest(test);
   }
 };
 
-export const itOnly = (
-  name: string,
-  f: MochaTypes.Func | MochaTypes.AsyncFunc,
-): void => {
+export const itOnly = (name: string, f: MochaTypes.Func | MochaTypes.AsyncFunc): void => {
   clearTests();
   const test = new Mocha.Test(name, f);
   mochaContext.addTest(test);
@@ -36,11 +35,9 @@ export const itOnly = (
 
 export const describe = (name: string, f: () => void): void => {
   const prevMochaContext = mochaContext;
-  mochaContext = new Mocha.Suite(
-    name,
-    prevMochaContext.ctx,
-  ) as MochaTypes.Suite;
+  mochaContext = new Mocha.Suite(name, prevMochaContext.ctx) as MochaTypes.Suite;
   prevMochaContext.addSuite(mochaContext);
+  console.log(`Running ${name}`);
   f();
   mochaContext = prevMochaContext;
 };

--- a/tests/tests/sqlite/rawQueries.spec.ts
+++ b/tests/tests/sqlite/rawQueries.spec.ts
@@ -193,7 +193,7 @@ export function registerBaseTests() {
 
       await db.writeTransaction(async (tx) => {
         await tx.execute('INSERT INTO "User" (id, name, age, networth) VALUES(?, ?, ?, ?)', [id, name, age, networth]);
-        // Purposely forget await this.
+        // Purposely forget await to this.
         tx.rollback();
       });
 

--- a/tests/tests/sqlite/rawQueries.spec.ts
+++ b/tests/tests/sqlite/rawQueries.spec.ts
@@ -389,32 +389,32 @@ export function registerBaseTests() {
       expect(result).to.equal(42);
     });
 
-    // it('Should queue simultaneous executions', async () => {
-    //   let order: number[] = [];
+    it('Should queue simultaneous executions', async () => {
+      let order: number[] = [];
 
-    //   const operationCount = 5;
-    //   // This wont resolve or free until another connection free's it
-    //   await db.writeLock(async (context) => {
-    //     await Promise.all(
-    //       Array(operationCount)
-    //         .fill(0)
-    //         .map(async (x: number, index: number) => {
-    //           try {
-    //             await context.execute('SELECT * FROM User');
-    //             order.push(index);
-    //           } catch (ex) {
-    //             console.error(ex);
-    //           }
-    //         })
-    //     );
-    //   });
+      const operationCount = 5;
+      // This wont resolve or free until another connection free's it
+      await db.writeLock(async (context) => {
+        await Promise.all(
+          Array(operationCount)
+            .fill(0)
+            .map(async (x: number, index: number) => {
+              try {
+                await context.execute('SELECT * FROM User');
+                order.push(index);
+              } catch (ex) {
+                console.error(ex);
+              }
+            })
+        );
+      });
 
-    //   expect(order).to.deep.equal(
-    //     Array(operationCount)
-    //       .fill(0)
-    //       .map((x, index) => index)
-    //   );
-    // });
+      expect(order).to.deep.equal(
+        Array(operationCount)
+          .fill(0)
+          .map((x, index) => index)
+      );
+    });
 
     it('Should call update hook on changes', async () => {
       const result = new Promise<UpdateNotification>((resolve) => db.registerUpdateHook((update) => resolve(update)));

--- a/tests/tests/sqlite/rawQueries.spec.ts
+++ b/tests/tests/sqlite/rawQueries.spec.ts
@@ -157,7 +157,7 @@ export function registerBaseTests() {
 
       await db.writeTransaction(async (tx) => {
         await tx.execute('INSERT INTO "User" (id, name, age, networth) VALUES(?, ?, ?, ?)', [id, name, age, networth]);
-        tx.commit();
+        await tx.commit();
       });
 
       const res = await db.execute('SELECT * FROM User');
@@ -176,7 +176,7 @@ export function registerBaseTests() {
 
       await db.writeTransaction(async (tx) => {
         await tx.execute('INSERT INTO "User" (id, name, age, networth) VALUES(?, ?, ?, ?)', [id, name, age, networth]);
-        tx.rollback();
+        await tx.rollback();
       });
 
       const res = await db.execute('SELECT * FROM User');

--- a/tests/tests/sqlite/rawQueries.spec.ts
+++ b/tests/tests/sqlite/rawQueries.spec.ts
@@ -389,32 +389,32 @@ export function registerBaseTests() {
       expect(result).to.equal(42);
     });
 
-    it('Should queue simultaneous executions', async () => {
-      let order: number[] = [];
+    // it('Should queue simultaneous executions', async () => {
+    //   let order: number[] = [];
 
-      const operationCount = 5;
-      // This wont resolve or free until another connection free's it
-      await db.writeLock(async (context) => {
-        await Promise.all(
-          Array(operationCount)
-            .fill(0)
-            .map(async (x: number, index: number) => {
-              try {
-                await context.execute('SELECT * FROM User');
-                order.push(index);
-              } catch (ex) {
-                console.error(ex);
-              }
-            })
-        );
-      });
+    //   const operationCount = 5;
+    //   // This wont resolve or free until another connection free's it
+    //   await db.writeLock(async (context) => {
+    //     await Promise.all(
+    //       Array(operationCount)
+    //         .fill(0)
+    //         .map(async (x: number, index: number) => {
+    //           try {
+    //             await context.execute('SELECT * FROM User');
+    //             order.push(index);
+    //           } catch (ex) {
+    //             console.error(ex);
+    //           }
+    //         })
+    //     );
+    //   });
 
-      expect(order).to.deep.equal(
-        Array(operationCount)
-          .fill(0)
-          .map((x, index) => index)
-      );
-    });
+    //   expect(order).to.deep.equal(
+    //     Array(operationCount)
+    //       .fill(0)
+    //       .map((x, index) => index)
+    //   );
+    // });
 
     it('Should call update hook on changes', async () => {
       const result = new Promise<UpdateNotification>((resolve) => db.registerUpdateHook((update) => resolve(update)));

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -6017,9 +6017,10 @@ react-native-quick-base64@^2.0.5:
     base64-js "^1.5.1"
 
 react-native-quick-sqlite@./..:
-  version "0.0.1"
+  version "0.1.0"
   dependencies:
     lodash "^4.17.21"
+    uuid "3.4.0"
 
 react-native-safe-area-context@^4.5.0:
   version "4.7.3"
@@ -7127,7 +7128,7 @@ utils-merge@1.0.1:
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^3.3.2, uuid@^3.4.0:
+uuid@3.4.0, uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6351,6 +6351,11 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
+uuid@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"


### PR DESCRIPTION
# Dependencies
The package dependency for `uuid` was missing. This would cause an error when requesting locks if the host application did not include the `uuid` package.

# Race Condition
The unit tests would intermittently fail in CI with no output. This was due to the unit "Manual Rollback" unit test omitting an `await` for `tx.rollback()`. The lock manager would wait for the work queue to empty before freeing the lock, but the mutex would not be notified, keeping the native connection state in an infinite loop. The mutex notification has been moved and a test has been added for cases where `await` is mistakingly ommited.