### PR TITLE
[Fix] Table change updates in write transactions

### DIFF
--- a/.changeset/chilled-queens-explain.md
+++ b/.changeset/chilled-queens-explain.md
@@ -2,4 +2,4 @@
 '@journeyapps/react-native-quick-sqlite': minor
 ---
 
-Fixed table change updates to only trigger change updates for changes made in `writeTransaction` and `writeLock`s which have been commited. Added ability to listen to all table change events as they occur. Added listeners for when a transaction has started, been commited or rolled back.
+Added `registerTablesChangedHook` to DB connections which reports batched table updates once `writeTransaction`s and `writeLock`s have been committed. Maintained API compatibility with `registerUpdateHook` which reports table change events as they occur. Added listeners for when write transactions have been committed or rolled back.

--- a/.changeset/chilled-queens-explain.md
+++ b/.changeset/chilled-queens-explain.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/react-native-quick-sqlite': minor
+---
+
+Fixed table change updates to only trigger change updates for changes made in `writeTransaction` and `writeLock`s which have been commited. Added ability to listen to all table change events as they occur. Added listeners for when a transaction has started, been commited or rolled back.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 ![screenshot](https://raw.githubusercontent.com/margelo/react-native-quick-sqlite/main/header2.png)
 
-testing
 <div align="center">
   <pre align="center">
     yarn add react-native-quick-sqlite

--- a/cpp/sqliteBridge.cpp
+++ b/cpp/sqliteBridge.cpp
@@ -40,6 +40,8 @@ sqliteOpenDb(string const dbName, string const docPath,
              void (*contextAvailableCallback)(std::string, ConnectionLockId),
              void (*updateTableCallback)(void *, int, const char *,
                                          const char *, sqlite3_int64),
+             void (*onTransactionFinalizedCallback)(
+                 const TransactionCallbackPayload *event),
              uint32_t numReadConnections) {
   if (dbMap.count(dbName) == 1) {
     return SQLiteOPResult{
@@ -51,6 +53,7 @@ sqliteOpenDb(string const dbName, string const docPath,
   dbMap[dbName] = new ConnectionPool(dbName, docPath, numReadConnections);
   dbMap[dbName]->setOnContextAvailable(contextAvailableCallback);
   dbMap[dbName]->setTableUpdateHandler(updateTableCallback);
+  dbMap[dbName]->setTransactionFinalizerHandler(onTransactionFinalizedCallback);
 
   return SQLiteOPResult{
       .type = SQLiteOk,

--- a/cpp/sqliteBridge.h
+++ b/cpp/sqliteBridge.h
@@ -29,6 +29,8 @@ sqliteOpenDb(std::string const dbName, std::string const docPath,
              void (*contextAvailableCallback)(std::string, ConnectionLockId),
              void (*updateTableCallback)(void *, int, const char *,
                                          const char *, sqlite3_int64),
+             void (*onTransactionFinalizedCallback)(
+                 const TransactionCallbackPayload *event),
              uint32_t numReadConnections);
 
 SQLiteOPResult sqliteCloseDb(string const dbName);

--- a/src/DBListenerManager.ts
+++ b/src/DBListenerManager.ts
@@ -70,7 +70,6 @@ export class DBListenerManagerInternal extends DBListenerManager {
   }
 
   flushUpdates() {
-    console.log('updates', this.updateBuffer);
     if (!this.updateBuffer.length) {
       return;
     }

--- a/src/DBListenerManager.ts
+++ b/src/DBListenerManager.ts
@@ -1,0 +1,96 @@
+import _ from 'lodash';
+import { registerUpdateHook } from './table-updates';
+import { UpdateCallback, UpdateNotification } from './types';
+import { BaseListener, BaseObserver } from './utils/BaseObserver';
+
+export interface DBListenerManagerOptions {
+  dbName: string;
+}
+
+export enum WriteTransactionEventType {
+  STARTED = 'started',
+  COMMIT = 'commit',
+  ROLLBACK = 'rollback'
+}
+
+export interface WriteTransactionEvent {
+  type: WriteTransactionEventType;
+}
+
+export interface DBListener extends BaseListener {
+  /**
+   * Register a listener to be fired for any table change.
+   * Changes inside write transactions are reported immediately.
+   */
+  rawTableChange: UpdateCallback;
+
+  /**
+   * Register a listener for when table changes are persisted
+   * into the DB. Changes during write transactions which are
+   * rolled back are not reported.
+   * Any changes during write transactions are buffered and reported
+   * after commit.
+   * Table changes are reported individually for now in order to maintain
+   * API compatibility. These can be batched in future.
+   */
+  tableUpdated: UpdateCallback;
+
+  /**
+   * Listener event triggered whenever a write transaction
+   * is started, committed or rolled back.
+   */
+  writeTransaction: (event: WriteTransactionEvent) => void;
+}
+
+export class DBListenerManager extends BaseObserver<DBListener> {}
+
+export class DBListenerManagerInternal extends DBListenerManager {
+  private _writeTransactionActive: boolean;
+  private updateBuffer: UpdateNotification[];
+
+  get writeTransactionActive() {
+    return this._writeTransactionActive;
+  }
+
+  constructor(protected options: DBListenerManagerOptions) {
+    super();
+    this._writeTransactionActive = false;
+    this.updateBuffer = [];
+    registerUpdateHook(this.options.dbName, (update) => this.handleTableUpdates(update));
+  }
+
+  transactionStarted() {
+    this._writeTransactionActive = true;
+    this.iterateListeners((l) => l?.writeTransaction?.({ type: WriteTransactionEventType.STARTED }));
+  }
+
+  transactionCommitted() {
+    this._writeTransactionActive = false;
+    // flush updates
+    const uniqueUpdates = _.uniq(this.updateBuffer);
+    this.updateBuffer = [];
+    this.iterateListeners((l) => {
+      l.writeTransaction?.({ type: WriteTransactionEventType.COMMIT });
+      uniqueUpdates.forEach((update) => l.tableUpdated?.(update));
+    });
+  }
+
+  transactionReverted() {
+    this._writeTransactionActive = false;
+    // clear updates
+    this.updateBuffer = [];
+    this.iterateListeners((l) => l?.writeTransaction?.({ type: WriteTransactionEventType.ROLLBACK }));
+  }
+
+  handleTableUpdates(notification: UpdateNotification) {
+    // Fire updates for any change
+    this.iterateListeners((l) => l.rawTableChange?.({ ...notification, pendingCommit: this._writeTransactionActive }));
+
+    if (this.writeTransactionActive) {
+      this.updateBuffer.push(notification);
+      return;
+    }
+
+    this.iterateListeners((l) => l.tableUpdated?.(notification));
+  }
+}

--- a/src/lock-hooks.ts
+++ b/src/lock-hooks.ts
@@ -2,16 +2,6 @@
  * Hooks which can be triggered during the execution of read/write locks
  */
 export interface LockHooks {
-  /**
-   * Executed after a SQL statement has been executed
-   */
-  execute?: (sql: string, args?: any[]) => Promise<void>;
   lockAcquired?: () => Promise<void>;
   lockReleased?: () => Promise<void>;
-}
-
-export interface TransactionHooks extends LockHooks {
-  begin?: () => Promise<void>;
-  commit?: () => Promise<void>;
-  rollback?: () => Promise<void>;
 }

--- a/src/lock-hooks.ts
+++ b/src/lock-hooks.ts
@@ -1,0 +1,17 @@
+/**
+ * Hooks which can be triggered during the execution of read/write locks
+ */
+export interface LockHooks {
+  /**
+   * Executed after a SQL statement has been executed
+   */
+  execute?: (sql: string, args?: any[]) => Promise<void>;
+  lockAcquired?: () => Promise<void>;
+  lockReleased?: () => Promise<void>;
+}
+
+export interface TransactionHooks extends LockHooks {
+  begin?: () => Promise<void>;
+  commit?: () => Promise<void>;
+  rollback?: () => Promise<void>;
+}

--- a/src/table-updates.ts
+++ b/src/table-updates.ts
@@ -1,6 +1,7 @@
-import { RowUpdateType, UpdateCallback } from './types';
+import { RowUpdateType, TransactionCallback, TransactionEvent, UpdateCallback } from './types';
 
 const updateCallbacks: Record<string, UpdateCallback> = {};
+const transactionCallbacks: Record<string, TransactionCallback> = {};
 
 /**
  * Entry point for update callbacks. This is triggered from C++ with params.
@@ -21,4 +22,21 @@ global.triggerUpdateHook = function (dbName: string, table: string, opType: RowU
 
 export const registerUpdateHook = (dbName: string, callback: UpdateCallback) => {
   updateCallbacks[dbName] = callback;
+};
+
+/**
+ * Entry point for transaction callbacks. This is triggered from C++ with params.
+ */
+global.triggerTransactionFinalizerHook = function (dbName: string, eventType: TransactionEvent) {
+  const callback = transactionCallbacks[dbName];
+  if (!callback) {
+    return;
+  }
+
+  callback(eventType);
+  return null;
+};
+
+export const registerTransactionHook = (dbName: string, callback: TransactionCallback) => {
+  transactionCallbacks[dbName] = callback;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { DBListenerManager } from './DBListenerManager';
+
 /**
  * Object returned by SQL Query executions {
  *  insertId: Represent the auto-generated row id if applicable
@@ -76,6 +78,11 @@ export interface UpdateNotification {
   opType: RowUpdateType;
   table: string;
   rowId: number;
+  /**
+   * If this change ocurred during a write transaction which has not been
+   * committed yet.
+   */
+  pendingCommit?: boolean;
 }
 
 export type UpdateCallback = (update: UpdateNotification) => void;
@@ -149,8 +156,9 @@ export type QuickSQLiteConnection = {
   executeBatch: (commands: SQLBatchTuple[]) => Promise<BatchQueryResult>;
   loadFile: (location: string) => Promise<FileLoadResult>;
   /**
-   * Note that only one listener can be registered per database connection.
-   * Any new hook registration will override the previous one.
+   * @deprecated
+   * Use listenerManager instead
    */
   registerUpdateHook(callback: UpdateCallback): void;
+  listenerManager: DBListenerManager;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,12 +172,12 @@ export type QuickSQLiteConnection = {
    * Table changes are reported immediately.
    * Changes might not yet be committed if using a transaction.
    *  - Listen to transaction events in listenerManager if extra logic is required
-   * For most use cases use `` instead.
+   * For most use cases use `registerTablesChangedHook` instead.
    * @returns a function which will deregister the callback
    */
   registerUpdateHook(callback: UpdateCallback): () => void;
   /**
-   * Register a callback which will be fired whenever a change to a ROWID table
+   * Register a callback which will be fired whenever a update to a ROWID table
    * has been committed.
    * Changes inside write locks will be buffered until the lock is released or
    * if a transaction inside the lock has been committed.

--- a/src/utils/BaseObserver.ts
+++ b/src/utils/BaseObserver.ts
@@ -1,0 +1,31 @@
+import { v4 } from 'uuid';
+
+export interface BaseObserverInterface<T extends BaseListener> {
+  registerListener(listener: Partial<T>): () => void;
+}
+
+export type BaseListener = {
+  [key: string]: (...event: any) => any;
+};
+
+export class BaseObserver<T extends BaseListener = BaseListener> implements BaseObserverInterface<T> {
+  protected listeners: { [id: string]: Partial<T> };
+
+  constructor() {
+    this.listeners = {};
+  }
+
+  registerListener(listener: Partial<T>): () => void {
+    const id = v4();
+    this.listeners[id] = listener;
+    return () => {
+      delete this.listeners[id];
+    };
+  }
+
+  iterateListeners(cb: (listener: Partial<T>) => any) {
+    for (let i in this.listeners) {
+      cb(this.listeners[i]);
+    }
+  }
+}

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -340,7 +340,7 @@ PODS:
     - glog
   - react-native-get-random-values (1.9.0):
     - React-Core
-  - react-native-quick-sqlite (0.0.1):
+  - react-native-quick-sqlite (1.0.0):
     - powersync-sqlite-core
     - React
     - React-callinvoker
@@ -658,7 +658,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 194e32c6aab382d88713ad3dd0025c5f5c4ee072
   React-logger: cebf22b6cf43434e471dc561e5911b40ac01d289
   react-native-get-random-values: dee677497c6a740b71e5612e8dbd83e7539ed5bb
-  react-native-quick-sqlite: bb695834cb1f4b88c3c2ae413ecf6522e9d221c3
+  react-native-quick-sqlite: d55edadf2d63f9ca9e3bc4bb138bf61739294413
   react-native-safe-area-context: 238cd8b619e05cb904ccad97ef42e84d1b5ae6ec
   React-NativeModulesApple: 02e35e9a51e10c6422f04f5e4076a7c02243fff2
   React-perflogger: e3596db7e753f51766bceadc061936ef1472edc3

--- a/tests/tests/sqlite/rawQueries.spec.ts
+++ b/tests/tests/sqlite/rawQueries.spec.ts
@@ -26,7 +26,7 @@ function createTestUser(context: { execute: (sql: string, args?: any[]) => Promi
   return context.execute('INSERT INTO "User" (id, name, age, networth) VALUES(?, ?, ?, ?)', [id, name, age, networth]);
 }
 
-const NUM_READ_CONNECTIONS = 5;
+const NUM_READ_CONNECTIONS = 3;
 
 export function registerBaseTests() {
   beforeEach(async () => {


### PR DESCRIPTION
This PR fixes an issue where table change updates registered via `registerUpdateHook` would trigger from `writeTransaction`s before the changes have been committed or rolled back. 

If a client used the update hook to trigger a read from a read connection the updated data would not yet be visible. This causes inconsistent results when implementing watched queries. 

This PR monitors the state of write transactions in order to emit update events only once the changes have been committed. This work is looseley based of the implementation here https://github.com/powersync-ja/sqlite_async.dart/blob/f994e165d5410c9ccca9a187de9c51fcedfd1182/lib/src/sqlite_connection_impl.dart#L310.

This PR also adds extra listeners which emit events for all table changes and write transaction events. This gives users access to table changes during transactions and allows for custom logic for deferring table change events during transactions. 