### PR TITLE
[Fix] Sqlite import redeclaration

### DIFF
--- a/.changeset/quiet-comics-grab.md
+++ b/.changeset/quiet-comics-grab.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/react-native-quick-sqlite': patch
+---
+
+Fixed incorrect imports of `sqlite3.h` to use local version.

--- a/cpp/fileUtils.cpp
+++ b/cpp/fileUtils.cpp
@@ -1,9 +1,9 @@
 #include "fileUtils.h"
 #include "logs.h"
+#include "sqlite3.h"
 #include <ctime>
 #include <iostream>
 #include <map>
-#include <sqlite3.h>
 #include <sstream>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/cpp/sqliteBridge.cpp
+++ b/cpp/sqliteBridge.cpp
@@ -11,10 +11,10 @@
 #include "ConnectionPool.h"
 #include "fileUtils.h"
 #include "logs.h"
+#include "sqlite3.h"
 #include <ctime>
 #include <iostream>
 #include <map>
-#include <sqlite3.h>
 #include <sstream>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/cpp/sqliteBridge.h
+++ b/cpp/sqliteBridge.h
@@ -9,7 +9,7 @@
 
 #include "ConnectionPool.h"
 #include "JSIHelper.h"
-#include <sqlite3.h>
+#include "sqlite3.h"
 #include <vector>
 
 #ifndef SQLiteBridge_h

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -37,7 +37,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.72.6)
   - hermes-engine/Pre-built (0.72.6)
   - libevent (2.1.12)
-  - powersync-sqlite-core (0.1.3)
+  - powersync-sqlite-core (0.1.6)
   - RCT-Folly (2021.07.22.00):
     - boost
     - DoubleConversion
@@ -340,11 +340,12 @@ PODS:
     - glog
   - react-native-get-random-values (1.9.0):
     - React-Core
-  - react-native-quick-sqlite (1.0.0):
-    - powersync-sqlite-core
+  - react-native-quick-sqlite (1.1.1):
+    - powersync-sqlite-core (~> 0.1.6)
     - React
     - React-callinvoker
     - React-Core
+    - sqlite3 (~> 3.42.0)
   - react-native-safe-area-context (4.7.3):
     - React-Core
   - React-NativeModulesApple (0.72.6):
@@ -458,6 +459,9 @@ PODS:
     - React-logger (= 0.72.6)
     - React-perflogger (= 0.72.6)
   - SocketRocket (0.6.1)
+  - sqlite3 (3.42.0):
+    - sqlite3/common (= 3.42.0)
+  - sqlite3/common (3.42.0)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -520,6 +524,7 @@ SPEC REPOS:
     - libevent
     - powersync-sqlite-core
     - SocketRocket
+    - sqlite3
 
 EXTERNAL SOURCES:
   boost:
@@ -641,7 +646,7 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 8057e75cfc1437b178ac86c8654b24e7fead7f60
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  powersync-sqlite-core: a8c9c0f5ddb25099973bece98776080400346fe3
+  powersync-sqlite-core: 4c38c8f470f6dca61346789fd5436a6826d1e3dd
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 28469809442eb4eb5528462705f7d852948c8a74
   RCTTypeSafety: e9c6c409fca2cc584e5b086862d562540cb38d29
@@ -658,7 +663,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 194e32c6aab382d88713ad3dd0025c5f5c4ee072
   React-logger: cebf22b6cf43434e471dc561e5911b40ac01d289
   react-native-get-random-values: dee677497c6a740b71e5612e8dbd83e7539ed5bb
-  react-native-quick-sqlite: d55edadf2d63f9ca9e3bc4bb138bf61739294413
+  react-native-quick-sqlite: 3fdffcf4e7752ab4231f5088c013fe0c78dc1ec8
   react-native-safe-area-context: 238cd8b619e05cb904ccad97ef42e84d1b5ae6ec
   React-NativeModulesApple: 02e35e9a51e10c6422f04f5e4076a7c02243fff2
   React-perflogger: e3596db7e753f51766bceadc061936ef1472edc3
@@ -678,6 +683,7 @@ SPEC CHECKSUMS:
   React-utils: fa59c9a3375fb6f4aeb66714fd3f7f76b43a9f16
   ReactCommon: dd03c17275c200496f346af93a7b94c53f3093a4
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
+  sqlite3: f163dbbb7aa3339ad8fc622782c2d9d7b72f7e9c
   Yoga: b76f1acfda8212aa16b7e26bcce3983230c82603
 
 PODFILE CHECKSUM: 1f188f526de7aeed7b7cf83c25ff1e25506d00fc

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -345,7 +345,6 @@ PODS:
     - React
     - React-callinvoker
     - React-Core
-    - sqlite3 (~> 3.42.0)
   - react-native-safe-area-context (4.7.3):
     - React-Core
   - React-NativeModulesApple (0.72.6):
@@ -459,9 +458,6 @@ PODS:
     - React-logger (= 0.72.6)
     - React-perflogger (= 0.72.6)
   - SocketRocket (0.6.1)
-  - sqlite3 (3.42.0):
-    - sqlite3/common (= 3.42.0)
-  - sqlite3/common (3.42.0)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -524,7 +520,6 @@ SPEC REPOS:
     - libevent
     - powersync-sqlite-core
     - SocketRocket
-    - sqlite3
 
 EXTERNAL SOURCES:
   boost:
@@ -663,7 +658,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 194e32c6aab382d88713ad3dd0025c5f5c4ee072
   React-logger: cebf22b6cf43434e471dc561e5911b40ac01d289
   react-native-get-random-values: dee677497c6a740b71e5612e8dbd83e7539ed5bb
-  react-native-quick-sqlite: 3fdffcf4e7752ab4231f5088c013fe0c78dc1ec8
+  react-native-quick-sqlite: b99b264d738643c12545519cffa449513a3a7c28
   react-native-safe-area-context: 238cd8b619e05cb904ccad97ef42e84d1b5ae6ec
   React-NativeModulesApple: 02e35e9a51e10c6422f04f5e4076a7c02243fff2
   React-perflogger: e3596db7e753f51766bceadc061936ef1472edc3
@@ -683,7 +678,6 @@ SPEC CHECKSUMS:
   React-utils: fa59c9a3375fb6f4aeb66714fd3f7f76b43a9f16
   ReactCommon: dd03c17275c200496f346af93a7b94c53f3093a4
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  sqlite3: f163dbbb7aa3339ad8fc622782c2d9d7b72f7e9c
   Yoga: b76f1acfda8212aa16b7e26bcce3983230c82603
 
 PODFILE CHECKSUM: 1f188f526de7aeed7b7cf83c25ff1e25506d00fc


### PR DESCRIPTION
Some files incorrectly imported sqlite3 with `#include <sqlite3.h>` instead of using the local `#include "sqlite3.h"`. 

This is mentioned in this issue  https://github.com/margelo/react-native-quick-sqlite/issues/12  with the same error present in the upstream codebase https://github.com/margelo/react-native-quick-sqlite/blob/be9235eef7d892ed46177f4d4031cc1a9af723ad/cpp/sqliteBridge.cpp#L13.

This would cause issues when building iOS applications which contained the `sqlite3` pod dependency as the compiler would see other SQLite3 declarations in `/usr/include`.

Example error:
```
(/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator17.2.sdk/usr/include/sqlite3.h:741:8)

  739 | */
  740 | typedef struct sqlite3_file sqlite3_file;
> 741 | struct sqlite3_file {
      |        ^ redefinition of 'sqlite3_file'
  742 |   const struct sqlite3_io_methods *pMethods;  /* Methods for an open file */
  743 | };
```

Testing:
This was tested in an Expo 50 application which uses the `expo-updates` NPM package which depends on the `sqlite3` pod. A development package was published and used there. It was verified that the iOS build step completed successfully. 


