### PR TITLE
Remove slower defer calls to improve INSERT performance

### DIFF
--- a/.changeset/four-meals-grab.md
+++ b/.changeset/four-meals-grab.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/react-native-quick-sqlite': patch
+---
+
+This pull request improves the performance of write operations especially INSERTs made outside a transaction context.

--- a/.changeset/four-meals-grab.md
+++ b/.changeset/four-meals-grab.md
@@ -2,4 +2,4 @@
 '@journeyapps/react-native-quick-sqlite': patch
 ---
 
-This pull request improves the performance of write operations especially INSERTs made outside a transaction context.
+This pull request improves the performance of releasing lock operations. Executing multiple lock operations, such as individual calls to `.execute`, should see a significant performance improvement.

--- a/src/setup-open.ts
+++ b/src/setup-open.ts
@@ -119,12 +119,13 @@ export function setupOpen(QuickSQLite: ISQLite) {
                 await hooks?.lockAcquired?.();
                 const res = await callback(context);
 
-                // Ensure that we only resolve after locks are freed
-                _.defer(() => resolve(res));
+                closeContextLock(dbName, id);
+                resolve(res)
               } catch (ex) {
-                _.defer(() => reject(ex));
+                closeContextLock(dbName, id);
+                reject(ex)
               } finally {
-                _.defer(() => hooks?.lockReleased?.());
+                hooks?.lockReleased?.()
               }
             }
           } as LockCallbackRecord);

--- a/src/setup-open.ts
+++ b/src/setup-open.ts
@@ -68,9 +68,6 @@ global.onLockContextIsAvailable = async (dbName: string, lockId: ContextLockID) 
       });
     } catch (ex) {
       console.error(ex);
-    } finally {
-      // Always release a lock once finished
-      closeContextLock(dbName, lockId);
     }
   });
 };
@@ -122,6 +119,7 @@ export function setupOpen(QuickSQLite: ISQLite) {
                 closeContextLock(dbName, id);
                 resolve(res)
               } catch (ex) {
+                closeContextLock(dbName, id);
                 reject(ex)
               } finally {
                 hooks?.lockReleased?.()

--- a/src/setup-open.ts
+++ b/src/setup-open.ts
@@ -122,7 +122,6 @@ export function setupOpen(QuickSQLite: ISQLite) {
                 closeContextLock(dbName, id);
                 resolve(res)
               } catch (ex) {
-                closeContextLock(dbName, id);
                 reject(ex)
               } finally {
                 hooks?.lockReleased?.()

--- a/tests/tests/sqlite/rawQueries.spec.ts
+++ b/tests/tests/sqlite/rawQueries.spec.ts
@@ -11,6 +11,7 @@ import {
 } from 'react-native-quick-sqlite';
 import { beforeEach, describe, it } from '../mocha/MochaRNAdapter';
 import chai from 'chai';
+import { randomIntFromInterval, numberName } from './utils';
 
 const { expect } = chai;
 const chance = new Chance();
@@ -62,6 +63,8 @@ export function registerBaseTests() {
 
       await db.execute('DROP TABLE IF EXISTS User; ');
       await db.execute('CREATE TABLE User ( id INT PRIMARY KEY, name TEXT NOT NULL, age INT, networth REAL) STRICT;');
+
+      await db.execute('CREATE TABLE IF NOT EXISTS t1(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER, c TEXT)');
     } catch (e) {
       console.warn('error on before each', e);
     }
@@ -589,6 +592,22 @@ export function registerBaseTests() {
       QuickSQLite.delete('single_connection');
 
       expect(result.rows?.length).to.equal(1);
+    });
+
+    it('10000 INSERTs', async () => {
+      let start = performance.now();
+      for (let i = 0; i < 1000; ++i) {
+        const n = randomIntFromInterval(0, 100000);
+        await db.execute(`INSERT INTO t1(a, b, c) VALUES(?, ?, ?)`, [
+          i + 1,
+          n,
+          numberName(n),
+        ]);
+      }
+      await db.execute('PRAGMA wal_checkpoint(RESTART)');
+      let end = performance.now();
+      let duration = end - start;
+      console.log(`10000 INSERTs :: ${duration}ms`);
     });
   });
 }

--- a/tests/tests/sqlite/rawQueries.spec.ts
+++ b/tests/tests/sqlite/rawQueries.spec.ts
@@ -607,7 +607,8 @@ export function registerBaseTests() {
       await db.execute('PRAGMA wal_checkpoint(RESTART)');
       let end = performance.now();
       let duration = end - start;
-      console.log(`10000 INSERTs :: ${duration}ms`);
+      
+      expect(duration).lessThan(2000);
     });
   });
 }

--- a/tests/tests/sqlite/utils.ts
+++ b/tests/tests/sqlite/utils.ts
@@ -1,0 +1,74 @@
+export function randomIntFromInterval(min: number, max: number) {
+  // min included and max excluded
+  return Math.random() * (max - min) + min;
+}
+
+export function numberName(n: number) {
+  if (n == 0) {
+    return 'zero';
+  }
+
+  let numberName: string[] = [];
+  let d43 = Math.floor(n / 1000);
+  if (d43 != 0) {
+    numberName.push(names100[d43]);
+    numberName.push('thousand');
+    n -= d43 * 1000;
+  }
+
+  let d2 = Math.floor(n / 100);
+  if (d2 != 0) {
+    numberName.push(names100[d2]);
+    numberName.push('hundred');
+    n -= d2 * 100;
+  }
+
+  let d10 = n;
+  if (d10 != 0) {
+    numberName.push(names100[d10]);
+  }
+
+  return numberName.join(' ');
+}
+
+export function assertAlways(condition: boolean) {
+  if (!condition) {
+    throw Error('Assertion failed');
+  }
+}
+
+const digits = [
+  '',
+  'one',
+  'two',
+  'three',
+  'four',
+  'five',
+  'six',
+  'seven',
+  'eight',
+  'nine',
+];
+const names100: string[] = [
+  ...digits,
+  ...[
+    'ten',
+    'eleven',
+    'twelve',
+    'thirteen',
+    'fourteen',
+    'fifteen',
+    'sixteen',
+    'seventeen',
+    'eighteen',
+    'nineteen',
+  ],
+  ...digits.map((digit) => `twenty${digit != '' ? '-' + digit : ''}`),
+  ...digits.map((digit) => `thirty${digit != '' ? '-' + digit : ''}`),
+  ...digits.map((digit) => `forty${digit != '' ? '-' + digit : ''}`),
+  ...digits.map((digit) => `fifty${digit != '' ? '-' + digit : ''}`),
+  ...digits.map((digit) => `sixty${digit != '' ? '-' + digit : ''}`),
+  ...digits.map((digit) => `seventy${digit != '' ? '-' + digit : ''}`),
+  ...digits.map((digit) => `eighty${digit != '' ? '-' + digit : ''}`),
+  ...digits.map((digit) => `ninety${digit != '' ? '-' + digit : ''}`),
+];


### PR DESCRIPTION
This pull request improves the performance of write operations especially INSERTs made outside a transaction context. The query time was reduced from an average time of `~14ms` to `~2ms`.

This was tested using the benchmark test of 1000 INSERTs. The time reduction was noted on both a simulator and a real device.