### PR TITLE
[Fix] Watched queries with large commits

### DIFF
--- a/.changeset/breezy-cougars-hope.md
+++ b/.changeset/breezy-cougars-hope.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/react-native-quick-sqlite': patch
+---
+
+Fix race condition where table change notications would trigger before COMMIT had completed.

--- a/src/DBListenerManager.ts
+++ b/src/DBListenerManager.ts
@@ -53,9 +53,10 @@ export class DBListenerManagerInternal extends DBListenerManager {
     registerUpdateHook(this.options.dbName, (update) => this.handleTableUpdates(update));
     registerTransactionHook(this.options.dbName, (eventType) => {
       switch (eventType) {
-        case TransactionEvent.COMMIT:
-          this.flushUpdates();
-          break;
+        /**
+         * COMMIT hooks occur before the commit is completed. This leads to race conditions.
+         * Only use the rollback event to clear updates.
+         */ 
         case TransactionEvent.ROLLBACK:
           this.transactionReverted();
           break;

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -930,7 +930,7 @@ PODS:
     - React-debug
   - react-native-get-random-values (1.9.0):
     - React-Core
-  - react-native-quick-sqlite (1.1.3):
+  - react-native-quick-sqlite (1.1.4):
     - powersync-sqlite-core (~> 0.1.6)
     - React
     - React-callinvoker
@@ -1321,7 +1321,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
-  DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
+  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   EASClient: a42ee8bf36c93b3128352faf2ae49405ab4f80bd
   EXConstants: 988aa430ca0f76b43cd46b66e7fae3287f9cc2fc
   EXFont: f20669cb266ef48b004f1eb1f2b20db96cd1df9f
@@ -1338,7 +1338,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 84f6edbe225f38aebd9deaf1540a4160b1f087d7
   FBReactNativeSpec: d0086a479be91c44ce4687a962956a352d2dc697
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
+  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: b2669ce35fc4ac14f523b307aff8896799829fe2
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   powersync-sqlite-core: 4c38c8f470f6dca61346789fd5436a6826d1e3dd
@@ -1365,7 +1365,7 @@ SPEC CHECKSUMS:
   React-logger: 0a57b68dd2aec7ff738195f081f0520724b35dab
   React-Mapbuffer: 63913773ed7f96b814a2521e13e6d010282096ad
   react-native-get-random-values: dee677497c6a740b71e5612e8dbd83e7539ed5bb
-  react-native-quick-sqlite: 2b663b5762b255d2047545fc95f58b0c246c265c
+  react-native-quick-sqlite: c4b0debdbfc2bcd282834f4268071e13a3c20cb4
   react-native-safe-area-context: 0ee144a6170530ccc37a0fd9388e28d06f516a89
   React-nativeconfig: d7af5bae6da70fa15ce44f045621cf99ed24087c
   React-NativeModulesApple: 0123905d5699853ac68519607555a9a4f5c7b3ac

--- a/tests/tests/mocha/MochaRNAdapter.ts
+++ b/tests/tests/mocha/MochaRNAdapter.ts
@@ -2,7 +2,7 @@ import 'mocha';
 import type * as MochaTypes from 'mocha';
 
 export const rootSuite = new Mocha.Suite('') as MochaTypes.Suite;
-rootSuite.timeout(30 * 1000);
+rootSuite.timeout(60 * 1000);
 
 let mochaContext = rootSuite;
 

--- a/tests/tests/mocha/MochaRNAdapter.ts
+++ b/tests/tests/mocha/MochaRNAdapter.ts
@@ -2,7 +2,7 @@ import 'mocha';
 import type * as MochaTypes from 'mocha';
 
 export const rootSuite = new Mocha.Suite('') as MochaTypes.Suite;
-rootSuite.timeout(10 * 1000);
+rootSuite.timeout(30 * 1000);
 
 let mochaContext = rootSuite;
 


### PR DESCRIPTION
Recently it was discovered that watched queries could fail when large data volumes were involved. 

This behaviour was traced down to the SQLite commit hooks firing before the commit has completed executing. The commit operation takes longer for larger data volumes, which causes watched queries to trigger before the data is available. 

This removes the use of the SQLite commit hook for flushing table changes. Tables changes are instead flushed when the write lock is freed. This is slightly less optimal, but is guaranteed for all data to be available before triggering table change notifications.