### PR TITLE
fix: large datasets on android 12 

### DIFF
--- a/.changeset/gorgeous-chefs-do.md
+++ b/.changeset/gorgeous-chefs-do.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/react-native-quick-sqlite': patch
+---
+
+Fixed order of makefile flags

--- a/.changeset/gorgeous-chefs-do.md
+++ b/.changeset/gorgeous-chefs-do.md
@@ -1,5 +1,0 @@
----
-'@journeyapps/react-native-quick-sqlite': patch
----
-
-Fixed order of makefile flags

--- a/.changeset/wise-stingrays-float.md
+++ b/.changeset/wise-stingrays-float.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/react-native-quick-sqlite': patch
+---
+
+Use memory temp_store

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -11,8 +11,8 @@ include_directories(
 )
 
 add_definitions(
-  ${SQLITE_FLAGS}
   -DSQLITE_TEMP_STORE=2
+  ${SQLITE_FLAGS}
 )
 
 add_library(

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -12,6 +12,7 @@ include_directories(
 
 add_definitions(
   ${SQLITE_FLAGS}
+  -DSQLITE_TEMP_STORE=2
 )
 
 add_library(

--- a/tests/tests/sqlite/rawQueries.spec.ts
+++ b/tests/tests/sqlite/rawQueries.spec.ts
@@ -566,9 +566,6 @@ export function registerBaseTests() {
       // Execute the read test whenever a table change ocurred
       db.registerTablesChangedHook((update) => readTriggerCallbacks.forEach((cb) => cb()));
 
-      // Needed for large volumes of data on older Android devices 
-      // https://github.com/margelo/react-native-quick-sqlite/pull/25
-      await db.execute('PRAGMA temp_store = memory;')
       const numberOfUsers = 100_000;
       await db.writeLock(async (tx) => {
         await tx.execute('BEGIN');


### PR DESCRIPTION
# Descriptions
Originally reported by an [end user](https://discord.com/channels/1138230179878154300/1229667462769934338)
On my side with 10k Todos I ran into an I/O error on Android 12 which has to do with the tmp dir not being available for some reason.

I originally had a fix with 
```
await this.database.execute('PRAGMA temp_store = file;');
await this.database.execute("PRAGMA temp_store_directory = '/data/user/0/com.powersync.example/cache'");
```
which works on runtime and would require me to use react-native-fs to identify the cache directory.

Upon looking for other solutions we found [this](https://github.com/OP-Engineering/op-sqlite/blob/43684d99f0327d6b25ca24559821a30c2073cf78/android/CMakeLists.txt#L48) with is compile time and in-memory meaning we don't need to depend on rn-fs


## Verify solution
User has confirmed that this solved their [issue](https://github.com/powersync-ja/react-native-quick-sqlite/pull/28).

### Extra
Related issues: https://github.com/margelo/react-native-quick-sqlite/pull/25