### PR TITLE
Upgrade minsdk to 23 for expo 51

### DIFF
--- a/.changeset/flat-brooms-kiss.md
+++ b/.changeset/flat-brooms-kiss.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/react-native-quick-sqlite': patch
+---
+
+Upgrade Android minSdk version to 23

--- a/.changeset/flat-brooms-kiss.md
+++ b/.changeset/flat-brooms-kiss.md
@@ -2,4 +2,4 @@
 '@journeyapps/react-native-quick-sqlite': patch
 ---
 
-Upgrade Android minSdk version to 23
+The default minimum SDK for Expo 51 is 23, so attempting to compile with our package using 21 would result in a build error.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -67,7 +67,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion 21 
+    minSdkVersion 23 
     targetSdkVersion safeExtGet('targetSdkVersion', 28)
     versionCode 1
     versionName "1.0"


### PR DESCRIPTION
## Description
The default minimum SDK for Expo 51 is 23, so attempting to compile with our package using 21 would result in a build error.

## Work done
- Upgrade minSDK to 23