### PR TITLE
[Fix] Double rollback calls in transactions

### DIFF
--- a/.changeset/rare-news-lie.md
+++ b/.changeset/rare-news-lie.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/react-native-quick-sqlite': patch
+---
+
+Silencing transactions that are reporting on failed rollback exceptions when they are safe to ignore.

--- a/src/setup-open.ts
+++ b/src/setup-open.ts
@@ -212,7 +212,12 @@ export function setupOpen(QuickSQLite: ISQLite) {
           }
           return res;
         } catch (ex) {
-          await rollback();
+          try {
+            await rollback();
+          } catch (ex2) {
+            // In rare cases, a rollback may fail.
+            // Safe to ignore.
+          }
           throw ex;
         }
       };


### PR DESCRIPTION
Users can easily trigger two rollback calls in transactions which causes an exception message users can't do anything about. This PR simply silences the exception when this happens as we do in [dart](https://github.com/powersync-ja/sqlite_async.dart/blob/4ba51e5a5bc4b6e47c4a21b658776fdce30a0548/packages/sqlite_async/lib/src/utils/shared_utils.dart#L33). Once merged I'll update `@powersync/react-native` and I'll be applying this change to `@powersync/web` too.
Example: 
```
PowerSync.writeTransaction<void>(async (trx) => {
  try {
   throw 'x';
  } catch(ex) {
    trx.rollback(); // explicit
    throw ex; // causes rollback call in wrapper
  }
})
```