### PR TITLE
chore: rename package to use @powersync instead of @journeyapps

### DIFF
--- a/.changeset/quick-trainers-marry.md
+++ b/.changeset/quick-trainers-marry.md
@@ -1,0 +1,5 @@
+---
+'@powersync/react-native-quick-sqlite': minor
+---
+
+Move package to @powersync/react-native-quick-sqlite

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-nodejs 16.19.0
+nodejs 18.12.0
 ruby 2.7.6
 yarn 1.22.19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# @journeyapps/react-native-quick-sqlite
+# @powersync/react-native-quick-sqlite
+
+## For the following previous versions refer to `@journeyapps/react-native-quick-sqlite`
 
 ## 1.1.8
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@journeyapps/react-native-quick-sqlite",
+  "name": "@powersync/react-native-quick-sqlite",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"
@@ -40,13 +40,13 @@
     "ios",
     "android"
   ],
-  "repository": "https://github.com/margelo/react-native-quick-sqlite",
+  "repository": "https://github.com/powersync-ja/react-native-quick-sqlite",
   "author": "JOURNEYAPPS",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/margelo/react-native-quick-sqlite/issues"
+    "url": "https://github.com/powersync-ja/react-native-quick-sqlite/issues"
   },
-  "homepage": "https://github.com/margelo/react-native-quick-sqlite#readme",
+  "homepage": "https://github.com/powersync-ja/react-native-quick-sqlite#readme",
   "devDependencies": {
     "@changesets/cli": "^2.26.2",
     "prettier": "^3.2.4",


### PR DESCRIPTION
## Description
This changes the name of the package to `@powersync/react-native-quick-sqlite`

Todos after this:
- [ ] We need to update docs with references to old package on Gitbook and other README's
- [ ] Update demos to use new package name