### PR TITLE
Use `install_modules_dependencies()` on iOS for newer react-native versions

### DIFF
--- a/.changeset/sour-pets-peel.md
+++ b/.changeset/sour-pets-peel.md
@@ -1,0 +1,5 @@
+---
+"@journeyapps/react-native-quick-sqlite": patch
+---
+
+Use install_modules_dependencies if available in newer react-native versions.

--- a/react-native-quick-sqlite.podspec
+++ b/react-native-quick-sqlite.podspec
@@ -26,14 +26,14 @@ Pod::Spec.new do |s|
   s.header_mappings_dir = "cpp"
   s.source_files = "ios/**/*.{h,hpp,m,mm}", "cpp/**/*.{h,cpp,c}"
 
+  s.dependency "React-callinvoker"
+  s.dependency "React"
+  s.dependency "powersync-sqlite-core", "~> 0.2.1"
   if defined?(install_modules_dependencies())
     install_modules_dependencies(s)
   else
-    s.dependency "React-callinvoker"
-    s.dependency "React"
     s.dependency "React-Core"
   end
-  s.dependency "powersync-sqlite-core", "~> 0.2.1"
 
   if ENV['QUICK_SQLITE_USE_PHONE_VERSION'] == '1' then
     s.exclude_files = "cpp/sqlite3.c", "cpp/sqlite3.h"

--- a/react-native-quick-sqlite.podspec
+++ b/react-native-quick-sqlite.podspec
@@ -26,9 +26,13 @@ Pod::Spec.new do |s|
   s.header_mappings_dir = "cpp"
   s.source_files = "ios/**/*.{h,hpp,m,mm}", "cpp/**/*.{h,cpp,c}"
 
-  s.dependency "React-callinvoker"
-  s.dependency "React"
-  s.dependency "React-Core"
+  if defined?(install_modules_dependencies())
+    install_modules_dependencies(s)
+  else
+    s.dependency "React-callinvoker"
+    s.dependency "React"
+    s.dependency "React-Core"
+  end
   s.dependency "powersync-sqlite-core", "~> 0.2.1"
 
   if ENV['QUICK_SQLITE_USE_PHONE_VERSION'] == '1' then


### PR DESCRIPTION
## Description

To ensure all necessary headers are included during the build process for React Native 0.74+, we were previously missing some header directories on iOS. `install_modules_dependencies()` installs React-Core and RCT-Folly as well as some New Architecture specific dependencies if New Architecture is enabled.
This change ensures all the required packages are included on newer react-native versions while maintaining backwards compatibility.

**Note**: This does not make the package compatible with New Architecture.

## Work done
- Use `install_modules_dependencies()` if available.
