### PR TITLE
Enable extension loading

### DIFF
--- a/.changeset/wise-ravens-kiss.md
+++ b/.changeset/wise-ravens-kiss.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/react-native-quick-sqlite': patch
+---
+
+Enable extension loading for all opened DB connections.

--- a/cpp/ConnectionState.cpp
+++ b/cpp/ConnectionState.cpp
@@ -116,5 +116,7 @@ SQLiteOPResult genericSqliteOpenDb(string const dbName, string const docPath,
                           .errorMessage = sqlite3_errmsg(*db)};
   }
 
+  sqlite3_enable_load_extension(*db, 1);
+
   return SQLiteOPResult{.type = SQLiteOk, .rowsAffected = 0};
 }


### PR DESCRIPTION
## Description

This change is required for loading extensions when using the library simultaneously with other SQLite libraries such as op-sqlite. When using this library simultaneously with other SQLite libraries it results in unpredictable behaviour. This is a workaround that enables extension loading in projects where other SQLite libraries are used that require extension loading.
This does not explicitly enable extension loading for this library but rather tries to assist with compatibility in the above scenarios.
This change is required for the work done in this [PR](https://github.com/powersync-ja/powersync-js/pull/300). 

**Note**: This change is not strictly required only for op-sqlite but makes the migration from RNQS to OPSQLite more convenient in the PowerSync JS SDK.

## Work done

- Enable extension loading for all DB connections