### PR TITLE
Fix journal_mode = WAL race condition

### DIFF
--- a/cpp/ConnectionPool.cpp
+++ b/cpp/ConnectionPool.cpp
@@ -26,26 +26,6 @@ ConnectionPool::ConnectionPool(std::string dbName, std::string docPath,
     readConnections[i] = new ConnectionState(
         dbName, docPath, SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX);
   }
-
-  if (true == isConcurrencyEnabled) {
-    // Write connection WAL setup
-    writeConnection.queueWork([](sqlite3 *db) {
-      sqliteExecuteLiteralWithDB(db, "PRAGMA journal_mode = WAL;");
-      sqliteExecuteLiteralWithDB(
-          db,
-          "PRAGMA journal_size_limit = 6291456"); // 6Mb 1.5x default checkpoint
-                                                  // size
-      // Default to normal on all connections
-      sqliteExecuteLiteralWithDB(db, "PRAGMA synchronous = NORMAL;");
-    });
-
-    // Read connections WAL setup
-    for (int i = 0; i < this->maxReads; i++) {
-      readConnections[i]->queueWork([](sqlite3 *db) {
-        sqliteExecuteLiteralWithDB(db, "PRAGMA synchronous = NORMAL;");
-      });
-    }
-  }
 };
 
 ConnectionPool::~ConnectionPool() {

--- a/cpp/ConnectionState.cpp
+++ b/cpp/ConnectionState.cpp
@@ -92,7 +92,7 @@ void ConnectionState::doWork() {
     // the queue is empty and not busy
     {
       std::unique_lock<std::mutex> g(workQueueMutex);
-    workQueueConditionVariable.notify_all();
+      workQueueConditionVariable.notify_all();
     }
   }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -26,7 +26,7 @@
     "nativewind": "^2.0.11",
     "react": "18.2.0",
     "react-native": "0.73.4",
-    "react-native-quick-sqlite": "./..",
+    "react-native-quick-sqlite": "link:..",
     "react-native-safe-area-context": "4.8.2",
     "reflect-metadata": "^0.1.13",
     "stream-browserify": "^3.0.0",

--- a/tests/tests/sqlite/rawQueries.spec.ts
+++ b/tests/tests/sqlite/rawQueries.spec.ts
@@ -629,5 +629,25 @@ export function registerBaseTests() {
 
       expect(duration).lessThan(2000);
     });
+
+    it('Should use WAL', async () => {
+      for (let i = 0; i < 5; i++) {
+        let db: QuickSQLiteConnection;
+        try {
+          db = open('test-wal' + i, {
+            numReadConnections: NUM_READ_CONNECTIONS
+          });
+
+          const journalMode = await db.execute('PRAGMA journal_mode');
+          const journalModeRO = await db.readLock((tx) => tx.execute('PRAGMA journal_mode'));
+          expect(journalMode.rows.item(0).journal_mode).equals('wal');
+
+          expect(journalModeRO.rows.item(0).journal_mode).equals('wal');
+        } finally {
+          db?.close();
+          db?.delete();
+        }
+      }
+    });
   });
 }

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -6259,8 +6259,9 @@ react-native-quick-base64@^2.0.5:
   dependencies:
     base64-js "^1.5.1"
 
-react-native-quick-sqlite@./..:
-  version "1.1.5"
+"react-native-quick-sqlite@link:..":
+  version "0.0.0"
+  uid ""
 
 react-native-safe-area-context@4.8.2:
   version "4.8.2"


### PR DESCRIPTION
Checking journal_mode in tests could reproduce the issue quite consistently - `journal_mode` would be the default `delete` instead of `wal` as it should be.

The issue appeared to be related to opening the write and read connections for the new database at the same time. The error is never actually reported (return code is ignored), but I've seen similar issues with Flutter where it would return a DATABASE_LOCKED or similar error in the initial PRAGMA statements.

The workaround here is to run the initial PRAGMA statements in the main thread, right after opening the database. This ensures the write connection is opened first, initializing the database, before the read connections are opened.

This also sets `PRAGMA busy_timeout` which did appear to help when executing concurrently, but did not cover all cases.

This also fixes some potential lock issues around `workQueue` being checked without locking first. I'm not aware of any actual issues this caused, but in theory this should be more stable.

