### PR TITLE
feat: refreshSchema

### DIFF
--- a/.changeset/angry-carrots-lay.md
+++ b/.changeset/angry-carrots-lay.md
@@ -2,4 +2,4 @@
 "@journeyapps/react-native-quick-sqlite": minor
 ---
 
-Added refreshSchema to bindings. Will cause all connections to be aware of a schema change.
+Added `refreshSchema()` to bindings. Will cause all connections to be aware of a schema change.

--- a/.changeset/angry-carrots-lay.md
+++ b/.changeset/angry-carrots-lay.md
@@ -1,0 +1,5 @@
+---
+"@journeyapps/react-native-quick-sqlite": minor
+---
+
+Added refreshSchema to bindings. Will cause all connections to be aware of a schema change.

--- a/cpp/ConnectionPool.cpp
+++ b/cpp/ConnectionPool.cpp
@@ -171,18 +171,15 @@ void ConnectionPool::closeAll() {
 std::future<void> ConnectionPool::refreshSchema() {
     std::vector<std::future<void>> futures;
 
-    // Collect the future from the write connection
     futures.push_back(writeConnection.refreshSchema());
 
-    // Collect the futures from the read connections
     for (unsigned int i = 0; i < maxReads; i++) {
         futures.push_back(readConnections[i]->refreshSchema());
     }
 
-    // Return a future that completes when all collected futures are done
     return std::async(std::launch::async, [futures = std::move(futures)]() mutable {
-        for (auto& fut : futures) {
-            fut.get(); // This will block until the future is ready and rethrow exceptions if any
+        for (auto& future : futures) {
+            future.get(); 
         }
     });
 }

--- a/cpp/ConnectionPool.cpp
+++ b/cpp/ConnectionPool.cpp
@@ -168,6 +168,14 @@ void ConnectionPool::closeAll() {
   }
 }
 
+void ConnectionPool::refreshSchema() {
+  writeConnection.refreshSchema();
+
+  for (unsigned int i = 0; i < maxReads; i++) {
+    readConnections[i]->refreshSchema();
+  }
+}
+
 SQLiteOPResult ConnectionPool::attachDatabase(std::string const dbFileName,
                                               std::string const docPath,
                                               std::string const alias) {

--- a/cpp/ConnectionPool.cpp
+++ b/cpp/ConnectionPool.cpp
@@ -168,12 +168,23 @@ void ConnectionPool::closeAll() {
   }
 }
 
-void ConnectionPool::refreshSchema() {
-  writeConnection.refreshSchema();
+std::future<void> ConnectionPool::refreshSchema() {
+    std::vector<std::future<void>> futures;
 
-  for (unsigned int i = 0; i < maxReads; i++) {
-    readConnections[i]->refreshSchema();
-  }
+    // Collect the future from the write connection
+    futures.push_back(writeConnection.refreshSchema());
+
+    // Collect the futures from the read connections
+    for (unsigned int i = 0; i < maxReads; i++) {
+        futures.push_back(readConnections[i]->refreshSchema());
+    }
+
+    // Return a future that completes when all collected futures are done
+    return std::async(std::launch::async, [futures = std::move(futures)]() mutable {
+        for (auto& fut : futures) {
+            fut.get(); // This will block until the future is ready and rethrow exceptions if any
+        }
+    });
 }
 
 SQLiteOPResult ConnectionPool::attachDatabase(std::string const dbFileName,

--- a/cpp/ConnectionPool.h
+++ b/cpp/ConnectionPool.h
@@ -130,7 +130,7 @@ public:
   /**
    * Refreshes the schema for all connections.
    */
-  std::future<void> ConnectionPool::refreshSchema();
+  std::future<void> refreshSchema();
 
   /**
    * Attaches another database to all connections

--- a/cpp/ConnectionPool.h
+++ b/cpp/ConnectionPool.h
@@ -127,6 +127,11 @@ public:
   void closeAll();
 
   /**
+   * Refreshes the schema for all connections.
+   */
+  void refreshSchema();
+
+  /**
    * Attaches another database to all connections
    */
   SQLiteOPResult attachDatabase(std::string const dbFileName,

--- a/cpp/ConnectionPool.h
+++ b/cpp/ConnectionPool.h
@@ -3,6 +3,7 @@
 #include "sqlite3.h"
 #include <string>
 #include <vector>
+#include <future>
 
 #ifndef ConnectionPool_h
 #define ConnectionPool_h
@@ -129,7 +130,7 @@ public:
   /**
    * Refreshes the schema for all connections.
    */
-  void refreshSchema();
+  std::future<void> ConnectionPool::refreshSchema();
 
   /**
    * Attaches another database to all connections

--- a/cpp/ConnectionState.cpp
+++ b/cpp/ConnectionState.cpp
@@ -2,8 +2,6 @@
 #include "fileUtils.h"
 #include "sqlite3.h"
 
-
-
 const std::string EMPTY_LOCK_ID = "";
 
 SQLiteOPResult genericSqliteOpenDb(string const dbName, string const docPath,
@@ -64,7 +62,6 @@ std::future<void> ConnectionState::refreshSchema() {
 
     return future;
 }
-
 
 void ConnectionState::close() {
   waitFinished();

--- a/cpp/ConnectionState.cpp
+++ b/cpp/ConnectionState.cpp
@@ -44,6 +44,12 @@ bool ConnectionState::matchesLock(const ConnectionLockId &lockId) {
 
 bool ConnectionState::isEmptyLock() { return _currentLockId == EMPTY_LOCK_ID; }
 
+void ConnectionState::refreshSchema() {
+  queueWork([this](sqlite3* db) {
+    sqlite3_exec(db, "PRAGMA table_info('sqlite_master')", nullptr, nullptr, nullptr);
+  });
+}
+
 void ConnectionState::close() {
   waitFinished();
   // So that the thread can stop (if not already)

--- a/cpp/ConnectionState.h
+++ b/cpp/ConnectionState.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <future>
 
 #ifndef ConnectionState_h
 #define ConnectionState_h
@@ -41,7 +42,7 @@ public:
   bool matchesLock(const ConnectionLockId &lockId);
   bool isEmptyLock();
 
-  void refreshSchema();
+  std::future<void> refreshSchema();
   void close();
   void queueWork(std::function<void(sqlite3 *)> task);
 

--- a/cpp/ConnectionState.h
+++ b/cpp/ConnectionState.h
@@ -41,6 +41,7 @@ public:
   bool matchesLock(const ConnectionLockId &lockId);
   bool isEmptyLock();
 
+  void refreshSchema();
   void close();
   void queueWork(std::function<void(sqlite3 *)> task);
 

--- a/cpp/bindings.cpp
+++ b/cpp/bindings.cpp
@@ -286,21 +286,21 @@ void osp::install(jsi::Runtime &rt,
     return {};
   });
 
-auto refreshSchema = HOSTFN("refreshSchema", 1) {
-    if (count == 0) {
-        throw jsi::JSError(rt, "[react-native-quick-sqlite][refreshSchema] database name is required");
-    }
+  auto refreshSchema = HOSTFN("refreshSchema", 1) {
+      if (count == 0) {
+          throw jsi::JSError(rt, "[react-native-quick-sqlite][refreshSchema] database name is required");
+      }
 
-    if (!args[0].isString()) {
-        throw jsi::JSError(rt, "[react-native-quick-sqlite][refreshSchema] database name must be a string");
-    }
+      if (!args[0].isString()) {
+          throw jsi::JSError(rt, "[react-native-quick-sqlite][refreshSchema] database name must be a string");
+      }
 
-    string dbName = args[0].asString(rt).utf8(rt);
+      string dbName = args[0].asString(rt).utf8(rt);
 
-    sqliteRefreshSchema(dbName);
+      sqliteRefreshSchema(dbName);
 
-    return {};
-});
+      return {};
+  });
 
   auto executeInContext = HOSTFN("executeInContext", 3) {
     if (count < 4) {

--- a/cpp/bindings.cpp
+++ b/cpp/bindings.cpp
@@ -286,6 +286,20 @@ void osp::install(jsi::Runtime &rt,
     return {};
   });
 
+auto refreshSchema = HOSTFN("refreshSchema", 1) {
+    if (count == 0) {
+        throw jsi::JSError(rt, "[react-native-quick-sqlite][refreshSchema] database name is required");
+    }
+
+    if (!args[0].isString()) {
+        throw jsi::JSError(rt, "[react-native-quick-sqlite][refreshSchema] database name must be a string");
+    }
+
+    string dbName = args[0].asString(rt).utf8(rt);
+
+    sqliteRefreshSchema(dbName);
+});
+
   auto executeInContext = HOSTFN("executeInContext", 3) {
     if (count < 4) {
       throw jsi::JSError(rt,
@@ -500,6 +514,7 @@ void osp::install(jsi::Runtime &rt,
   module.setProperty(rt, "releaseLock", move(releaseLock));
   module.setProperty(rt, "executeInContext", move(executeInContext));
   module.setProperty(rt, "close", move(close));
+  module.setProperty(rt, "refreshSchema", move(refreshSchema));
 
   module.setProperty(rt, "attach", move(attach));
   module.setProperty(rt, "detach", move(detach));

--- a/cpp/bindings.cpp
+++ b/cpp/bindings.cpp
@@ -298,6 +298,8 @@ auto refreshSchema = HOSTFN("refreshSchema", 1) {
     string dbName = args[0].asString(rt).utf8(rt);
 
     sqliteRefreshSchema(dbName);
+
+    return {};
 });
 
   auto executeInContext = HOSTFN("executeInContext", 3) {

--- a/cpp/bindings.cpp
+++ b/cpp/bindings.cpp
@@ -286,7 +286,6 @@ void osp::install(jsi::Runtime &rt,
     return {};
   });
 
-  
   auto refreshSchema = HOSTFN("refreshSchema", 1) {
     if (count == 0) {
         throw jsi::JSError(rt, "[react-native-quick-sqlite][refreshSchema] database name is required");
@@ -323,9 +322,7 @@ void osp::install(jsi::Runtime &rt,
             }).detach();
 
         } catch (const std::exception& exc) {
-            auto errorCtr = rt.global().getPropertyAsFunction(rt, "Error");
-            auto error = errorCtr.callAsConstructor(rt, jsi::String::createFromUtf8(rt, exc.what()));
-            reject->asObject(rt).asFunction(rt).call(rt, error);
+            invoker->invokeAsync([&rt, &exc] { jsi::JSError(rt, exc.what()); });
         }
 
         return {};

--- a/cpp/sqliteBridge.cpp
+++ b/cpp/sqliteBridge.cpp
@@ -60,10 +60,8 @@ sqliteOpenDb(string const dbName, string const docPath,
   };
 }
 
-
 std::future<void> sqliteRefreshSchema(const std::string& dbName) {
     if (dbMap.count(dbName) == 0) {
-        // Database not found, return a future that's already set
         std::promise<void> promise;
         promise.set_value();
         return promise.get_future();
@@ -72,7 +70,6 @@ std::future<void> sqliteRefreshSchema(const std::string& dbName) {
     ConnectionPool* connection = dbMap[dbName];
     return connection->refreshSchema();
 }
-
 
 SQLiteOPResult sqliteCloseDb(string const dbName) {
   if (dbMap.count(dbName) == 0) {

--- a/cpp/sqliteBridge.cpp
+++ b/cpp/sqliteBridge.cpp
@@ -60,14 +60,17 @@ sqliteOpenDb(string const dbName, string const docPath,
   };
 }
 
-void sqliteRefreshSchema(string const dbName) {
-  if (dbMap.count(dbName) == 0) {
-   // Do nothing 
-    return;
-  }
 
-  ConnectionPool *connection = dbMap[dbName];
-  connection->refreshSchema();
+std::future<void> sqliteRefreshSchema(const std::string& dbName) {
+    if (dbMap.count(dbName) == 0) {
+        // Database not found, return a future that's already set
+        std::promise<void> promise;
+        promise.set_value();
+        return promise.get_future();
+    }
+
+    ConnectionPool* connection = dbMap[dbName];
+    return connection->refreshSchema();
 }
 
 

--- a/cpp/sqliteBridge.cpp
+++ b/cpp/sqliteBridge.cpp
@@ -60,6 +60,17 @@ sqliteOpenDb(string const dbName, string const docPath,
   };
 }
 
+void sqliteRefreshSchema(string const dbName) {
+  if (dbMap.count(dbName) == 0) {
+   // Do nothing 
+    return;
+  }
+
+  ConnectionPool *connection = dbMap[dbName];
+  connection->refreshSchema();
+}
+
+
 SQLiteOPResult sqliteCloseDb(string const dbName) {
   if (dbMap.count(dbName) == 0) {
     return generateNotOpenResult(dbName);

--- a/cpp/sqliteBridge.h
+++ b/cpp/sqliteBridge.h
@@ -11,6 +11,7 @@
 #include "JSIHelper.h"
 #include "sqlite3.h"
 #include <vector>
+#include <future>
 
 #ifndef SQLiteBridge_h
 #define SQLiteBridge_h
@@ -33,7 +34,7 @@ sqliteOpenDb(std::string const dbName, std::string const docPath,
                  const TransactionCallbackPayload *event),
              uint32_t numReadConnections);
 
-void sqliteRefreshSchema(string const dbName);
+std::future<void> sqliteRefreshSchema(const std::string& dbName);
 
 SQLiteOPResult sqliteCloseDb(string const dbName);
 

--- a/cpp/sqliteBridge.h
+++ b/cpp/sqliteBridge.h
@@ -33,6 +33,8 @@ sqliteOpenDb(std::string const dbName, std::string const docPath,
                  const TransactionCallbackPayload *event),
              uint32_t numReadConnections);
 
+void sqliteRefreshSchema(string const dbName);
+
 SQLiteOPResult sqliteCloseDb(string const dbName);
 
 void sqliteCloseAll();

--- a/src/setup-open.ts
+++ b/src/setup-open.ts
@@ -225,6 +225,7 @@ export function setupOpen(QuickSQLite: ISQLite) {
       // Return the concurrent connection object
       return {
         close: () => QuickSQLite.close(dbName),
+        refreshSchema: () => QuickSQLite.refreshSchema(dbName),
         execute: (sql: string, args?: any[]) => writeLock((context) => context.execute(sql, args)),
         readLock,
         readTransaction: async <T>(callback: (context: TransactionContext) => Promise<T>, options?: LockOptions) =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,7 @@ export interface ISQLite {
   open: Open;
   close: (dbName: string) => void;
   delete: (dbName: string, location?: string) => void;
+  refreshSchema: (dbName: string) => void;
 
   requestLock: (dbName: string, id: ContextLockID, type: ConcurrentLockType) => QueryResult;
   releaseLock(dbName: string, id: ContextLockID): void;
@@ -151,6 +152,7 @@ export interface TransactionContext extends LockContext {
 
 export type QuickSQLiteConnection = {
   close: () => void;
+  refreshSchema: () => void;
   execute: (sql: string, args?: any[]) => Promise<QueryResult>;
   readLock: <T>(callback: (context: LockContext) => Promise<T>, options?: LockOptions) => Promise<T>;
   readTransaction: <T>(callback: (context: TransactionContext) => Promise<T>, options?: LockOptions) => Promise<T>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,7 +124,7 @@ export interface ISQLite {
   open: Open;
   close: (dbName: string) => void;
   delete: (dbName: string, location?: string) => void;
-  refreshSchema: (dbName: string) => void;
+  refreshSchema: (dbName: string) => Promise<void>;
 
   requestLock: (dbName: string, id: ContextLockID, type: ConcurrentLockType) => QueryResult;
   releaseLock(dbName: string, id: ContextLockID): void;
@@ -152,7 +152,7 @@ export interface TransactionContext extends LockContext {
 
 export type QuickSQLiteConnection = {
   close: () => void;
-  refreshSchema: () => void;
+  refreshSchema: () => Promise<void>;
   execute: (sql: string, args?: any[]) => Promise<QueryResult>;
   readLock: <T>(callback: (context: LockContext) => Promise<T>, options?: LockOptions) => Promise<T>;
   readTransaction: <T>(callback: (context: TransactionContext) => Promise<T>, options?: LockOptions) => Promise<T>;


### PR DESCRIPTION
The changeset adds a refreshSchema function which ensures that all write/read connections are aware of changes made to the schema.

This was tested via a dev package release in `powersync-js`.

A similar addition was made to `sqlite-async` [here](https://github.com/powersync-ja/sqlite_async.dart/pull/57).