### PR TITLE
Feat: Enable FTS5

### DIFF
--- a/.changeset/brown-beers-grow.md
+++ b/.changeset/brown-beers-grow.md
@@ -1,0 +1,5 @@
+---
+"@journeyapps/react-native-quick-sqlite": patch
+---
+
+Enable FTS5

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -12,6 +12,7 @@ include_directories(
 
 add_definitions(
   -DSQLITE_TEMP_STORE=2
+  -DSQLITE_ENABLE_FTS5=1
   ${SQLITE_FLAGS}
 )
 

--- a/react-native-quick-sqlite.podspec
+++ b/react-native-quick-sqlite.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/margelo/react-native-quick-sqlite.git", :tag => "#{s.version}" }
 
   s.pod_target_xcconfig = {
-    :GCC_PREPROCESSOR_DEFINITIONS => "HAVE_FULLFSYNC=1",
+    :GCC_PREPROCESSOR_DEFINITIONS => "HAVE_FULLFSYNC=1 SQLITE_ENABLE_FTS5=1",
     :WARNING_CFLAGS => "-Wno-shorten-64-to-32 -Wno-comma -Wno-unreachable-code -Wno-conditional-uninitialized -Wno-deprecated-declarations",
     :USE_HEADERMAP => "No"
   }


### PR DESCRIPTION
## Description

This PR enables FTS5 using the compiler option. This is inline with other SDKs like Dart and JS Web.

## Work done

- Enable FTS5 for android and iOS by default