### PR TITLE
Fix crashes when binding or reading blob values

### DIFF
--- a/.changeset/six-moose-buy.md
+++ b/.changeset/six-moose-buy.md
@@ -1,0 +1,5 @@
+---
+"@journeyapps/react-native-quick-sqlite": patch
+---
+
+Fix crash when binding or reading blobs.

--- a/cpp/JSIHelper.h
+++ b/cpp/JSIHelper.h
@@ -41,8 +41,7 @@ struct QuickValue
   double doubleOrIntValue;
   long long int64Value;
   string textValue;
-  shared_ptr<uint8_t> arrayBufferValue;
-  size_t arrayBufferSize;
+  vector<uint8_t> arrayBuffer;
 };
 
 /**
@@ -108,7 +107,7 @@ QuickValue createIntegerQuickValue(int value);
 QuickValue createIntegerQuickValue(double value);
 QuickValue createInt64QuickValue(long long value);
 QuickValue createDoubleQuickValue(double value);
-QuickValue createArrayBufferQuickValue(uint8_t *arrayBufferValue, size_t arrayBufferSize);
+QuickValue createArrayBufferQuickValueByCopying(const uint8_t *arrayBufferValue, size_t arrayBufferSize);
 jsi::Value createSequelQueryExecutionResult(jsi::Runtime &rt, SQLiteOPResult status, vector<map<string, QuickValue>> *results, vector<QuickColumnMetadata> *metadata);
 
 #endif /* JSIHelper_h */

--- a/cpp/sqliteExecute.cpp
+++ b/cpp/sqliteExecute.cpp
@@ -8,7 +8,7 @@ void bindStatement(sqlite3_stmt *statement, vector<QuickValue> *values) {
 
   for (int ii = 0; ii < size; ii++) {
     int sqIndex = ii + 1;
-    QuickValue value = values->at(ii);
+    const QuickValue& value = values->at(ii);
     QuickDataType dataType = value.dataType;
     if (dataType == NULL_VALUE) {
       sqlite3_bind_null(statement, sqIndex);
@@ -24,8 +24,8 @@ void bindStatement(sqlite3_stmt *statement, vector<QuickValue> *values) {
       sqlite3_bind_text(statement, sqIndex, value.textValue.c_str(),
                         value.textValue.length(), SQLITE_TRANSIENT);
     } else if (dataType == ARRAY_BUFFER) {
-      sqlite3_bind_blob(statement, sqIndex, value.arrayBufferValue.get(),
-                        value.arrayBufferSize, SQLITE_STATIC);
+      sqlite3_bind_blob(statement, sqIndex, value.arrayBuffer.data(),
+                        value.arrayBuffer.size(), SQLITE_STATIC);
     }
   }
 }
@@ -114,9 +114,7 @@ sqliteExecuteWithDB(sqlite3 *db, std::string const &query,
         case SQLITE_BLOB: {
           int blob_size = sqlite3_column_bytes(statement, i);
           const void *blob = sqlite3_column_blob(statement, i);
-          uint8_t *data;
-          memcpy(data, blob, blob_size);
-          row[column_name] = createArrayBufferQuickValue(data, blob_size);
+          row[column_name] = createArrayBufferQuickValueByCopying(static_cast<const uint8_t*>(blob), blob_size);
           break;
         }
 

--- a/tests/tests/sqlite/rawQueries.spec.ts
+++ b/tests/tests/sqlite/rawQueries.spec.ts
@@ -133,6 +133,21 @@ export function registerBaseTests() {
       ]);
     });
 
+    it('binding blobs', async () => {
+      const data = new TextEncoder().encode('hello blob');
+      const res = await db.execute('SELECT hex(?) AS r', [data.buffer]);
+
+      expect(res.rows?._array).to.eql([{ r: '68656C6C6F20626C6F62' }]);
+    });
+
+    it('reading blobs', async () => {
+      const res = await db.execute('SELECT unhex(1234) AS r');
+      const value = res.rows._array[0].r;
+
+      expect(value).to.be.instanceOf(ArrayBuffer);
+      expect([...new Uint8Array(value)]).to.eql([18, 52]);
+    });
+
     it('Failed insert', async () => {
       const id = chance.string(); // Setting the id to a string will throw an exception, it expects an int
       const { name, age, networth } = generateUserInfo();


### PR DESCRIPTION
This fixes two issues:

1. When binding a JS `ArrayBuffer` as a blob value, we used to pass the underlying data pointer of the buffer to the `shared_ptr` constructor. This makes the value take ownership of the underlying contents, which is not correct! The JS engine keeps ownership of data, we should clone instead. Binding the buffer causes a duplicate free when the JS engine eventually collects garbage, crashing the app.
2. When reading `SQLITE_BLOB` values, `memcpy` was called on an uninitialized `uint8_t *`. Writing into the uninitialized pointer is undefined behavior (crashing the app is a best-case scenario here).