### PR TITLE
Update powersync-sqlite-core to 0.4.0

### DIFF
--- a/.changeset/polite-phones-divide.md
+++ b/.changeset/polite-phones-divide.md
@@ -1,0 +1,5 @@
+---
+"@journeyapps/react-native-quick-sqlite": patch
+---
+
+Use powersync-sqlite-core version 0.4.0

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -113,7 +113,7 @@ android {
 }
 
 dependencies {
-  implementation 'co.powersync:powersync-sqlite-core:0.3.14'
+  implementation 'co.powersync:powersync-sqlite-core:0.4.0'
   //noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-android:+'
 }

--- a/react-native-quick-sqlite.podspec
+++ b/react-native-quick-sqlite.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
 
   s.dependency "React-callinvoker"
   s.dependency "React"
-  s.dependency "powersync-sqlite-core", "~> 0.3.14"
+  s.dependency "powersync-sqlite-core", "0.4.0"
   if defined?(install_modules_dependencies())
     install_modules_dependencies(s)
   else

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -44,7 +44,7 @@ PODS:
   - hermes-engine (0.76.6):
     - hermes-engine/Pre-built (= 0.76.6)
   - hermes-engine/Pre-built (0.76.6)
-  - powersync-sqlite-core (0.3.14)
+  - powersync-sqlite-core (0.4.0)
   - RCT-Folly (2024.01.01.00):
     - boost
     - DoubleConversion
@@ -1280,11 +1280,11 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-quick-sqlite (2.4.2):
+  - react-native-quick-sqlite (2.4.4):
     - DoubleConversion
     - glog
     - hermes-engine
-    - powersync-sqlite-core (~> 0.3.14)
+    - powersync-sqlite-core (= 0.4.0)
     - RCT-Folly (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
@@ -1822,7 +1822,7 @@ SPEC CHECKSUMS:
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 1949ca944b195a8bde7cbf6316b9068e19cf53c6
-  powersync-sqlite-core: ef06642c8110680fcddce8a8c0dd2696daaf672d
+  powersync-sqlite-core: 3bfe9a3c210e130583496871b404f18d4cfbe366
   RCT-Folly: 84578c8756030547307e4572ab1947de1685c599
   RCTDeprecation: 063fc281b30b7dc944c98fe53a7e266dab1a8706
   RCTRequired: 8eda2a5a745f6081157a4f34baac40b65fe02b31
@@ -1852,7 +1852,7 @@ SPEC CHECKSUMS:
   React-logger: d42a53754a7252cc7a851315f0da2e46b450ea92
   React-Mapbuffer: 89885d1518433a462fe64b68bf5e097997380090
   React-microtasksnativemodule: 9010f5187c13b6734cf80358870fff6f3b6fc7b3
-  react-native-quick-sqlite: e3c28a4b18be814d2290489df6e9090f0ce542f1
+  react-native-quick-sqlite: 8ecf53893426715e2336e88235be69d87787f499
   react-native-safe-area-context: 8b8404e70b0cbf2a56428a17017c14c1dcc16448
   React-nativeconfig: 539ff4de6ce3b694e8e751080568c281c84903ce
   React-NativeModulesApple: 702246817c286d057e23fe4b1302019796e62521


### PR DESCRIPTION
This updates the core extension to 0.4.0. It also adopts an exact version dependency for CocoaPods on iOS, allowing users to more easily downgrade their PowerSync version if needed (downgrading their SDK version should also downgrade all transitive powersync dependencies like the core extension version).