### PR TITLE
Update runner for iOS build test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -85,7 +85,7 @@ jobs:
 
   test-ios:
     name: Test iOS (Only build)
-    runs-on: macOS-13
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
`macOS-13` is no longer supported, so this uses `macos-latest`.