### PR TITLE
Update core extension to 0.4.12

### DIFF
--- a/.changeset/tricky-planets-vanish.md
+++ b/.changeset/tricky-planets-vanish.md
@@ -1,0 +1,5 @@
+---
+"@journeyapps/react-native-quick-sqlite": patch
+---
+
+Update PowerSync SQLite core extension to 0.4.12

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -115,7 +115,7 @@ android {
 }
 
 dependencies {
-  implementation 'com.powersync:powersync-sqlite-core:0.4.11'
+  implementation 'com.powersync:powersync-sqlite-core:0.4.12'
   //noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-android:+'
 }

--- a/react-native-quick-sqlite.podspec
+++ b/react-native-quick-sqlite.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
 
   s.dependency "React-callinvoker"
   s.dependency "React"
-  s.dependency "powersync-sqlite-core", "0.4.11"
+  s.dependency "powersync-sqlite-core", "0.4.12"
   if defined?(install_modules_dependencies())
     install_modules_dependencies(s)
   else

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -44,7 +44,7 @@ PODS:
   - hermes-engine (0.76.6):
     - hermes-engine/Pre-built (= 0.76.6)
   - hermes-engine/Pre-built (0.76.6)
-  - powersync-sqlite-core (0.4.11)
+  - powersync-sqlite-core (0.4.12)
   - RCT-Folly (2024.01.01.00):
     - boost
     - DoubleConversion
@@ -1280,11 +1280,11 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-quick-sqlite (2.5.0):
+  - react-native-quick-sqlite (2.5.1):
     - DoubleConversion
     - glog
     - hermes-engine
-    - powersync-sqlite-core (= 0.4.11)
+    - powersync-sqlite-core (= 0.4.12)
     - RCT-Folly (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
@@ -1822,7 +1822,7 @@ SPEC CHECKSUMS:
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 1949ca944b195a8bde7cbf6316b9068e19cf53c6
-  powersync-sqlite-core: aae0128de5f062c8e5a6bc450090ebba0b398222
+  powersync-sqlite-core: 116ecf3391859445f1477f8c230914e04d9874e7
   RCT-Folly: 84578c8756030547307e4572ab1947de1685c599
   RCTDeprecation: 063fc281b30b7dc944c98fe53a7e266dab1a8706
   RCTRequired: 8eda2a5a745f6081157a4f34baac40b65fe02b31
@@ -1852,7 +1852,7 @@ SPEC CHECKSUMS:
   React-logger: d42a53754a7252cc7a851315f0da2e46b450ea92
   React-Mapbuffer: 89885d1518433a462fe64b68bf5e097997380090
   React-microtasksnativemodule: 9010f5187c13b6734cf80358870fff6f3b6fc7b3
-  react-native-quick-sqlite: c530920909c97de71bd711b76cdc1a6eeb91b129
+  react-native-quick-sqlite: e37977ae215c91b97fd0539207549e73ce31291d
   react-native-safe-area-context: 8b8404e70b0cbf2a56428a17017c14c1dcc16448
   React-nativeconfig: 539ff4de6ce3b694e8e751080568c281c84903ce
   React-NativeModulesApple: 702246817c286d057e23fe4b1302019796e62521


### PR DESCRIPTION
This updates the core extension to [version 0.4.12](https://github.com/powersync-ja/powersync-sqlite-core/releases/tag/v0.4.12).